### PR TITLE
Remove vendor reference on option_types view

### DIFF
--- a/app/views/spree/admin/option_types/index.html.erb
+++ b/app/views/spree/admin/option_types/index.html.erb
@@ -24,10 +24,7 @@
     <tr data-hook="option_header">
       <th></th>
       <th><%= Spree::OptionType.human_attribute_name(:name) %></th>
-      <th><%= Spree::OptionType.human_attribute_name(:presentation) %></th>
-      <% if current_spree_user.respond_to?(:has_spree_role?) && current_spree_user.has_spree_role?(:admin) %>
-        <th><%= Spree.t(:vendor_name) %>
-      <% end %>
+      <th><%= Spree::OptionType.human_attribute_name(:presentation) %></th>>
       <th class="actions"></th>
     </tr>
     </thead>
@@ -37,9 +34,6 @@
         <td><span class="handle"></span></td>
         <td><%= option_type.name %></td>
         <td class="presentation"><%= option_type.presentation %></td>
-        <% if current_spree_user.respond_to?(:has_spree_role?) && current_spree_user.has_spree_role?(:admin) %>
-          <td><%= option_type.vendor.try(:name) %>
-        <% end %>
         <td class="actions">
           <% if can?(:update, option_type) %>
             <%= link_to_edit(option_type, class: 'admin_edit_option_type', no_text: true) %>


### PR DESCRIPTION
Here its using `vendor` reference on `option_types` https://github.com/Bevvinc/solidus_multi_vendor/blob/master/app/views/spree/admin/option_types/index.html.erb#L41