### PR TITLE
Add deface to Gemfile

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -10,10 +10,4 @@ else
   gem 'rails_test_params_backport', group: :test
 end
 
-gem 'pg'
-gem 'sqlite3'
-gem 'mysql2'
-
-gem 'deface'
-
 gemspec

--- a/Gemfile
+++ b/Gemfile
@@ -14,4 +14,6 @@ gem 'pg'
 gem 'sqlite3'
 gem 'mysql2'
 
+gem 'deface'
+
 gemspec

--- a/solidus_multi_vendor.gemspec
+++ b/solidus_multi_vendor.gemspec
@@ -23,6 +23,7 @@ Gem::Specification.new do |s|
   solidus_version = ['>= 1.0', '< 3']
   s.add_dependency 'solidus_core', solidus_version
   s.add_dependency 'solidus_support'
+  s.add_dependency 'deface'
 
   s.add_development_dependency 'capybara'
   s.add_development_dependency 'capybara-screenshot'
@@ -35,6 +36,7 @@ Gem::Specification.new do |s|
   s.add_development_dependency 'sass-rails'
   s.add_development_dependency 'selenium-webdriver'
   s.add_development_dependency 'simplecov'
+  s.add_development_dependency 'sqlite3'
   s.add_development_dependency 'pg'
   s.add_development_dependency 'mysql2'
   s.add_development_dependency 'appraisal'


### PR DESCRIPTION
Deface is not required anymore by solidus, it should be added to the Gemfile, if not, it should be motioned to add the gem manually in the installation instructions in the README.